### PR TITLE
Adds a test case for decoding UTF-8 strings and fixes this bug

### DIFF
--- a/lib/php_serialize.rb
+++ b/lib/php_serialize.rb
@@ -3,6 +3,8 @@
 require 'stringio'
 
 module PHP
+	ENCODING = 'utf-8'
+
 	class StringIOReader < StringIO
 		# Reads data from the buffer until +char+ is found. The
 		# returned string will include +char+.
@@ -245,7 +247,7 @@ module PHP
 
 			when 's' # string, s:length:"data";
 				len = string.read_until(':').to_i + 3 # quotes, separator
-				val = string.read(len)[1...-2] # read it, kill useless quotes
+				val = string.read(len)[1...-2].force_encoding(ENCODING) # read it, kill useless quotes
 
 			when 'i' # integer, i:123
 				val = string.read_until(';').to_i

--- a/test/php_serialize_test.rb
+++ b/test/php_serialize_test.rb
@@ -76,6 +76,7 @@ class TestPhpSerialize < Test::Unit::TestCase
   # PHP counts multibyte string, not string length
   def test_multibyte_string
     assert_equal  "s:6:\"öäü\";", PHP.serialize("öäü")
+    assert_equal  PHP.unserialize("s:6:\"öäü\";"), "öäü"
   end
 	# Verify assoc is passed down calls.
 	# Slightly awkward because hashes don't guarantee order.


### PR DESCRIPTION
Multibyte strings were not being encoded back into UTF-8, so I wrote a test case (and fixed the bug)
