### PR TITLE
Hashes & Arrays with multibyte characters raise a TypeError

### DIFF
--- a/test.rb
+++ b/test.rb
@@ -77,6 +77,7 @@ class TestPhpSerialize < Test::Unit::TestCase
   def test_multibyte_string
     assert_equal  "s:6:\"öäü\";", PHP.serialize("öäü")
   end
+
 	# Verify assoc is passed down calls.
 	# Slightly awkward because hashes don't guarantee order.
 	def test_assoc
@@ -86,6 +87,24 @@ class TestPhpSerialize < Test::Unit::TestCase
 			phps = [
 				'a:2:{s:4:"hash";a:1:{s:4:"hash";s:5:"smoke";}s:3:"foo";a:2:{i:0;s:3:"bar";i:1;s:3:"baz";}}',
 				'a:2:{s:3:"foo";a:2:{i:0;s:3:"bar";i:1;s:3:"baz";}s:4:"hash";a:1:{s:4:"hash";s:5:"smoke";}}'
+			]
+			serialized = PHP.serialize(ruby, true)
+			assert phps.include?(serialized)
+			unserialized = PHP.unserialize(serialized, true)
+			assert_equal ruby_assoc.sort, unserialized.sort
+		end
+	end
+
+	# Multibyte version.
+	# Verify assoc is passed down calls.
+	# Slightly awkward because hashes don't guarantee order.
+	def test_assoc_multibyte
+		assert_nothing_raised do
+			ruby = {'ああ' => ['öäü','漢字'], 'hash' => {'おはよう' => 'smoke'}}
+			ruby_assoc = [['ああ', ['öäü','漢字']], ['hash', [['おはよう','smoke']]]]
+			phps = [
+				'a:2:{s:6:"ああ";a:2:{i:0;s:6:"öäü";i:1;s:6:"漢字";}s:4:"hash";a:1:{s:12:"おはよう";s:5:"smoke";}}',
+				'a:2:{s:4:"hash";a:1:{s:12:"おはよう";s:5:"smoke";}s:6:"ああ";a:2:{i:0;s:6:"öäü";i:1;s:6:"漢字";}}'
 			]
 			serialized = PHP.serialize(ruby, true)
 			assert phps.include?(serialized)


### PR DESCRIPTION
It seems that a couple of the latest commits break hashes / arrays with multibyte characters. I've written a failing test case, and the error message is the following:

```
test_assoc_multibyte(TestPhpSerialize) [test.rb:102]:
Exception raised:
<#<TypeError: Unable to unserialize type 'h'>>.
```

Re-basing to 32463ff6e837b7e003fca02a98af995177471924 seems to work, and since commits since then are performance related (and not bug fixes), fixing this wasn't a high priority for the app I'm using this library in. It should be fixed, though.. Can someone help me out? :smiley: 
