### PR TITLE
Fix warning from JRuby

### DIFF
--- a/lib/php_serialize.rb
+++ b/lib/php_serialize.rb
@@ -109,7 +109,7 @@ module PHP
 				s << 'N;'
 
 			when FalseClass, TrueClass
-				s << "b:#{var ? 1 :0};"
+				s << "b:#{var ? 1 : 0};"
 
 			else
 				if var.respond_to?(:to_assoc)


### PR DESCRIPTION
Thanks for this super handy little gem.  Here's a quick fix for a warning JRuby throws.

Here's what the warning looks like :
```
jruby-9.1.1.0 :003 > require 'php_serialize'
/home/nehresman/.rvm/gems/jruby-9.1.1.0@sentry_adt_poc/gems/php_serialize-1.2/lib/php_serialize.rb:102: warning: `:' after local variable or literal is interpreted as binary operator
/home/nehresman/.rvm/gems/jruby-9.1.1.0@sentry_adt_poc/gems/php_serialize-1.2/lib/php_serialize.rb:102: warning: even though it seems like symbol literal
```