### PR TITLE
Fix Fixnum deprecation warning

### DIFF
--- a/lib/php_serialize.rb
+++ b/lib/php_serialize.rb
@@ -63,7 +63,7 @@ module PHP
 			when String, Symbol
 				s << "s:#{var.to_s.bytesize}:\"#{var.to_s}\";"
 
-			when Fixnum # PHP doesn't have bignums
+			when Integer
 				s << "i:#{var};"
 
 			when Float


### PR DESCRIPTION
Aloha, I thought I'd share this in case it saves you a few keypresses.

I made this change to remove the `Fixnum` deprecation warning in ruby 2.4. From the looks of it this should be fine for older versions of ruby. All tests continue to pass.

Integer is the base class of Fixnum and Bignum, so this commit changes functionality slightly. It now allows Bignums to be formatted - maybe this isn't useful though.