### PR TITLE
Introduce PHP::PhpObject to handle repeating stdClass with different property sets

### DIFF
--- a/test/php_serialize_test.rb
+++ b/test/php_serialize_test.rb
@@ -108,10 +108,25 @@ class TestPhpSerialize < Test::Unit::TestCase
 		end
 	end
 
-  def test_new_struct_creation
-    assert_nothing_raised do
-      phps = 'O:8:"stdClass":2:{s:3:"url";s:17:"/legacy/index.php";s:8:"dateTime";s:19:"2012-10-24 22:29:13";}'
-      PHP.unserialize(phps)
-    end
-  end
+	def test_creates_php_object_instance_if_class_undefined
+		assert_nothing_raised do
+			phps = 'O:8:"stdClass":2:{s:3:"url";s:17:"/legacy/index.php";s:8:"dateTime";s:19:"2012-10-24 22:29:13";}'
+			serialized = PHP.unserialize(phps)
+
+			assert_kind_of PHP::PhpObject, serialized
+			assert_equal "/legacy/index.php", serialized.url
+
+			reserialized = PHP.serialize(phps)
+			assert_equal phps, reserialized
+		end
+	end
+
+	def test_same_classname_appears_twice
+		assert_nothing_raised do
+			# can be generated with:
+			# 	serialize([(object)["foo" => 1], (object)["bar" => 2]])
+			phps = 'a:2:{i:0;O:8:"stdClass":1:{s:3:"foo";i:1;}i:1;O:8:"stdClass":1:{s:3:"bar";i:2;}}'
+			PHP.unserialize(phps)
+		end
+	end
 end


### PR DESCRIPTION
## Problem

stdClass object may appears twice or more with difference properties as shown in the example below:

```php
echo serialize([(object)["foo" => 1], (object)["bar" => 2]]);
# => 
#   a:2:{i:0;O:8:"stdClass":1:{s:3:"foo";i:1;}i:1;O:8:"stdClass":1:{s:3:"bar";i:2;}}
```

However, the current implementation creates `Struct::stdClass` class with only the `foo` member
when it met the first serialized object.

Then during processing the 2nd object, it tries to instantiate `Struct::stdClass` with properties set `["bar" => 2]`, 
and this ends up `undefined method bar=` error.

## Solution

I introduced a new `PHP::PhpObject` class to represent an unserialized object instead of using Struct. 
This is a subclass of [OpenStruct](https://ruby-doc.org/3.2.2/stdlibs/ostruct/OpenStruct.html) so that it can accept any property assignments from serialized objects.

Also it can be re-serialized as it was before unserializing, keeping both the properties order and the object's class name. (stored in `PhpObject#_php_classname`)
